### PR TITLE
Added ansible_managed header to template files

### DIFF
--- a/templates/unison.service.j2
+++ b/templates/unison.service.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 [Unit]
 Description=Unison file-synchronizer
 After=multi-user.target

--- a/templates/vagrant.prf.j2
+++ b/templates/vagrant.prf.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 # Unison preferences
 label = Mirror home directory
 root = /home/vagrant


### PR DESCRIPTION
This is useful to tell users that a file has been placed by Ansible and manual changes are likely to be overwritten.
