### PR TITLE
Specify hosts to testinfa via python

### DIFF
--- a/molecule.yml
+++ b/molecule.yml
@@ -10,6 +10,3 @@ docker:
   - name: ansible-role-unison-01
     image: ubuntu
     image_version: '16.04'
-
-testinfra:
-  hosts: ansible-role-unison-01

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,3 +1,8 @@
+from testinfra.utils.ansible_runner import AnsibleRunner
+
+testinfra_hosts = AnsibleRunner('.molecule/ansible_inventory').get_hosts('all')
+
+
 def test_unison(Sudo, Command, File):
     with Sudo('vagrant'):
         # Clean up any previous runs


### PR DESCRIPTION
Was specifying hosts via molecule.yml file. The new approach is dynamic and avoids repeating configuration information.
