### PR TITLE
Make FAT/Windows support configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ unison_src_root: '/home/vagrant'
 
 # Path to root directory of mirrored files
 unison_mirror_root: '/vagrant/home'
+
+# Make Unison work with the limitations of the Windows file system
+unison_fat: yes
 ```
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,6 @@ unison_src_root: '/home/vagrant'
 
 # Path to root directory of mirrored files
 unison_mirror_root: '/vagrant/home'
+
+# Make Unison work with the limitations of the Windows file system
+unison_fat: yes

--- a/templates/vagrant.prf.j2
+++ b/templates/vagrant.prf.j2
@@ -23,7 +23,7 @@ nodeletionpartial = BelowPath .ssh -> {{ unison_src_root }}
 noupdatepartial = Path .ssh/authorized_keys -> {{ unison_src_root }}
 
 # Make it work with limitations of Windows file system
-fat = true
+fat={{ unison_fat | bool | ternary('true', 'false') }}
 
 # Don't ask for confirmation for non-conflicting files
 auto=true


### PR DESCRIPTION
Windows support was on by default; this resulted in inferior behaviour when both filesystems were native Linux; FAT/Windows support can now be disabled through configuration.
